### PR TITLE
Round 2 of cleaning up `SpiTupleTable`

### DIFF
--- a/pgrx-examples/bgworker/src/lib.rs
+++ b/pgrx-examples/bgworker/src/lib.rs
@@ -67,15 +67,15 @@ pub extern "C" fn background_worker_main(arg: pg_sys::Datum) {
         // within a transaction, execute an SQL statement, and log its results
         let result: Result<(), pgrx::spi::Error> = BackgroundWorker::transaction(|| {
             Spi::connect(|client| {
-                let tuple_table = client.select(
+                let mut tuple_table = client.select(
                     "SELECT 'Hi', id, ''||a FROM (SELECT id, 42 from generate_series(1,10) id) a ",
                     None,
                     None,
                 )?;
-                for tuple in tuple_table {
-                    let a = tuple.get_datum_by_ordinal(1)?.value::<String>()?;
-                    let b = tuple.get_datum_by_ordinal(2)?.value::<i32>()?;
-                    let c = tuple.get_datum_by_ordinal(3)?.value::<String>()?;
+                while let Some(tuple) = tuple_table.next() {
+                    let a = tuple[1].value::<String>()?;
+                    let b = tuple[2].value::<i32>()?;
+                    let c = tuple[3].value::<String>()?;
                     log!("from bgworker: ({:?}, {:?}, {:?})", a, b, c);
                 }
                 Ok(())

--- a/pgrx-examples/custom_sql/src/lib.rs
+++ b/pgrx-examples/custom_sql/src/lib.rs
@@ -106,32 +106,6 @@ mod tests {
         );
         Ok(())
     }
-
-    /*
-       #[pg_test]
-       fn test_ordering() -> Result<(), spi::Error> {
-           let buf = Spi::connect(|client| {
-               client
-                   .select("SELECT * FROM extension_sql", None, None)?
-                   .map(|tup| tup[1].value())
-                   .collect::<spi::Result<Vec<Option<String>>>>()
-           })?;
-
-           assert_eq!(
-               buf,
-               vec![
-                   Some(String::from("bootstrap")),
-                   Some(String::from("single_raw")),
-                   Some(String::from("single")),
-                   Some(String::from("multiple_raw")),
-                   Some(String::from("multiple")),
-                   Some(String::from("finalizer"))
-               ]
-           );
-           Ok(())
-       }
-
-    */
 }
 
 #[cfg(test)]

--- a/pgrx-examples/schemas/src/lib.rs
+++ b/pgrx-examples/schemas/src/lib.rs
@@ -101,7 +101,7 @@ mod tests {
 
     #[pg_test]
     fn test_my_some_schema_type() -> Result<(), spi::Error> {
-        Spi::connect(|mut c| {
+        Spi::connect(|c| {
             // "MySomeSchemaType" is in 'some_schema', so it needs to be discoverable
             c.update("SET search_path TO some_schema,public", None, None)?;
             assert_eq!(

--- a/pgrx-examples/spi/src/lib.rs
+++ b/pgrx-examples/spi/src/lib.rs
@@ -119,7 +119,7 @@ fn issue1209_fixed() -> Result<Option<String>, Box<dyn std::error::Error>> {
     let res = Spi::connect(|c| {
         let mut cursor = c.open_cursor("SELECT 'hello' FROM generate_series(1, 10000)", None);
         let table = cursor.fetch(10000)?;
-        table.into_iter().map(|row| row.get::<&str>(1)).collect::<Result<Vec<_>, _>>()
+        table.map(|row| row.get::<&str>(1)).collect::<Result<Vec<_>, _>>()
     })?;
 
     Ok(res.first().cloned().flatten().map(|s| s.to_string()))

--- a/pgrx-tests/src/tests/spi_tests.rs
+++ b/pgrx-tests/src/tests/spi_tests.rs
@@ -196,7 +196,7 @@ mod tests {
 
     fn sum_all(table: pgrx::spi::SpiTupleTable) -> i32 {
         table
-            .map(|r| r.get_datum_by_ordinal(1)?.value::<i32>())
+            .map(|r| r.get_one::<i32>())
             .map(|r| r.expect("failed to get ordinal #1").expect("ordinal #1 was null"))
             .sum()
     }
@@ -356,7 +356,6 @@ mod tests {
             let _b = client.select("SELECT 1 WHERE 'f'", None, None)?;
             assert!(!a.is_empty());
             assert_eq!(1, a.len());
-            assert!(a.get_heap_tuple().is_ok());
             assert_eq!(Ok(Some(1)), a.get::<i32>(1));
             Ok(())
         })
@@ -372,7 +371,6 @@ mod tests {
             let _b = client.select("SELECT 1", None, None)?;
             assert!(a.is_empty());
             assert_eq!(0, a.len());
-            assert!(a.get_heap_tuple().is_ok());
             assert_eq!(Err(pgrx::spi::Error::InvalidPosition), a.get::<i32>(1));
             Ok(())
         })
@@ -540,7 +538,7 @@ mod tests {
         let res = Spi::connect(|c| {
             let mut cursor = c.open_cursor("SELECT 'hello' FROM generate_series(1, 10000)", None);
             let table = cursor.fetch(10000)?;
-            table.into_iter().map(|row| row.get::<&str>(1)).collect::<Result<Vec<_>, _>>()
+            table.map(|row| row.get::<&str>(1)).collect::<Result<Vec<_>, _>>()
         })?;
 
         let value = res.first().cloned().flatten().map(|s| s.to_string());

--- a/pgrx/src/spi.rs
+++ b/pgrx/src/spi.rs
@@ -22,7 +22,7 @@ mod tuple;
 pub use client::SpiClient;
 pub use cursor::SpiCursor;
 pub use query::{OwnedPreparedStatement, PreparedStatement, Query};
-pub use tuple::{SpiHeapTupleData, SpiHeapTupleDataEntry, SpiTupleTable};
+pub use tuple::SpiTupleTable;
 
 pub type SpiResult<T> = std::result::Result<T, SpiError>;
 pub use SpiResult as Result;

--- a/pgrx/src/spi/tuple.rs
+++ b/pgrx/src/spi/tuple.rs
@@ -1,37 +1,177 @@
+use std::cell::RefCell;
 use std::ffi::{CStr, CString};
 use std::fmt::Debug;
 use std::marker::PhantomData;
 use std::ops::Index;
 use std::ptr::NonNull;
+use std::rc::Rc;
 
 use crate::memcxt::PgMemoryContexts;
-use crate::pg_sys::panic::ErrorReportable;
 use crate::pg_sys::{self, PgOid};
 use crate::prelude::*;
 use crate::spi::SpiClient;
 
 use super::{SpiError, SpiErrorCodes, SpiResult};
 
-#[derive(Debug)]
-pub struct SpiTupleTable<'client> {
-    // SpiTupleTable borrows global state setup by the active SpiClient.  It doesn't use the client
-    // directly, but we need to make sure we don't outlive it, so here it is
+#[derive(Debug, Clone)]
+struct Inner<'client> {
+    // We borrow global state setup by the active SpiClient (pg_sys::SPI_tuptable).  We don't use
+    // the client directly, but do need to make sure we don't outlive it, so here it is
     _client: PhantomData<&'client SpiClient>,
 
-    // and this is that global state.  In ::wrap(), this comes from whatever the current value of
+    // and this is that global state.  In SpiTupleTable::wrap(), this comes from whatever the current value of
     // `pg_sys::SPI_tuptable` happens to be.  Postgres may change where SPI_tuptable points
     // throughout the lifetime of an active SpiClient, but it doesn't mutate (or deallocate) what
-    // it happens to point to  This allows us to have multiple active SpiTupleTables
+    // it happens to point to.  This allows us to have multiple active SpiTupleTables
     // within a Spi connection.  Whatever this points to is freed via `pg_sys::SPI_freetuptable()`
-    // when we're dropped.
+    // when it is dropped.
     table: Option<NonNull<pg_sys::SPITupleTable>>,
     size: usize,
-    current: isize,
+
+    // within the `SPITupleTable`, which row are we pointing at?
+    current: Rc<RefCell<Option<usize>>>,
+}
+
+impl<'client> Inner<'client> {
+    #[inline(always)]
+    fn get_spi_tuptable(
+        &self,
+    ) -> SpiResult<(*mut pg_sys::SPITupleTable, *mut pg_sys::TupleDescData)> {
+        let table = self.table.map(|table| table.as_ptr()).ok_or(SpiError::NoTupleTable)?;
+        let tupdesc = unsafe {
+            // SAFETY:  we just assured that `table` is not null
+            table.as_mut().unwrap().tupdesc
+        };
+        Ok((table, tupdesc))
+    }
+
+    fn get<T: IntoDatum + FromDatum>(&self, ordinal: usize) -> SpiResult<Option<T>> {
+        let (_, tupdesc) = self.get_spi_tuptable()?;
+        let datum = self.get_datum_by_ordinal(ordinal)?;
+        let is_null = datum.is_none();
+        let datum = datum.unwrap_or_else(|| pg_sys::Datum::from(0));
+
+        unsafe {
+            // SAFETY:  we know the constraints around `datum` and `is_null` match because we
+            // just got them from the underlying heap tuple
+            Ok(T::try_from_datum_in_memory_context(
+                PgMemoryContexts::CurrentMemoryContext
+                    .parent()
+                    .expect("parent memory context is absent"),
+                datum,
+                is_null,
+                // SAFETY:  we know `self.tupdesc.is_some()` because an Ok return from
+                // `self.get_datum_by_ordinal()` above already decided that for us
+                pg_sys::SPI_gettypeid(tupdesc, ordinal as _),
+            )?)
+        }
+    }
+
+    /// Get a raw Datum from this HeapTuple by its ordinal position.
+    ///
+    /// The ordinal position is 1-based.
+    ///
+    /// # Errors
+    ///
+    /// If the specified ordinal is out of bounds a [`Error::SpiError(SpiError::NoAttribute)`] is returned
+    /// If we have no backing tuple table a [`Error::NoTupleTable`] is returned
+    fn get_datum_by_ordinal(&self, ordinal: usize) -> SpiResult<Option<pg_sys::Datum>> {
+        self.check_ordinal_bounds(ordinal)?;
+
+        let (table, tupdesc) = self.get_spi_tuptable()?;
+
+        match self.current.borrow().as_ref() {
+            None => Err(SpiError::InvalidPosition),
+            Some(i) if *i >= self.size => Err(SpiError::InvalidPosition),
+            Some(i) => unsafe {
+                let heap_tuple = std::slice::from_raw_parts((*table).vals, self.size)[*i];
+                let mut is_null = false;
+                let datum = pg_sys::SPI_getbinval(heap_tuple, tupdesc, ordinal as _, &mut is_null);
+
+                if is_null {
+                    Ok(None)
+                } else {
+                    Ok(Some(datum))
+                }
+            },
+        }
+    }
+
+    fn columns(&self) -> SpiResult<usize> {
+        let (_, tupdesc) = self.get_spi_tuptable()?;
+        // SAFETY:  we just got a valid tupdesc
+        Ok(unsafe { (*tupdesc).natts as _ })
+    }
+
+    #[inline]
+    fn check_ordinal_bounds(&self, ordinal: usize) -> SpiResult<()> {
+        if ordinal < 1 || ordinal > self.columns()? {
+            Err(SpiError::SpiError(SpiErrorCodes::NoAttribute))
+        } else {
+            Ok(())
+        }
+    }
+
+    fn column_type_oid(&self, ordinal: usize) -> SpiResult<PgOid> {
+        self.check_ordinal_bounds(ordinal)?;
+
+        let (_, tupdesc) = self.get_spi_tuptable()?;
+        unsafe {
+            // SAFETY:  we just got a valid tupdesc
+            let oid = pg_sys::SPI_gettypeid(tupdesc, ordinal as i32);
+            Ok(PgOid::from(oid))
+        }
+    }
+
+    fn column_name(&self, ordinal: usize) -> SpiResult<String> {
+        self.check_ordinal_bounds(ordinal)?;
+        let (_, tupdesc) = self.get_spi_tuptable()?;
+        unsafe {
+            // SAFETY:  we just got a valid tupdesc and we know ordinal is in bounds
+            let name = pg_sys::SPI_fname(tupdesc, ordinal as i32);
+
+            // SAFETY:  SPI_fname will have given us a properly allocated char* since we know
+            // the specified ordinal is in bounds
+            let str =
+                CStr::from_ptr(name).to_str().expect("column name is not value UTF8").to_string();
+
+            // SAFETY: we just asked Postgres to allocate name for us
+            pg_sys::pfree(name as *mut _);
+            Ok(str)
+        }
+    }
+
+    fn column_ordinal<S: AsRef<str>>(&self, name: S) -> SpiResult<usize> {
+        let (_, tupdesc) = self.get_spi_tuptable()?;
+        unsafe {
+            let name_cstr = CString::new(name.as_ref()).expect("name contained a null byte");
+            let fnumber = pg_sys::SPI_fnumber(tupdesc, name_cstr.as_ptr());
+
+            if fnumber == pg_sys::SPI_ERROR_NOATTRIBUTE {
+                Err(SpiError::SpiError(SpiErrorCodes::NoAttribute))
+            } else {
+                Ok(fnumber as usize)
+            }
+        }
+    }
+}
+
+#[derive(Debug)]
+pub struct SpiTupleTable<'client> {
+    inner: Inner<'client>,
+    entries: Vec<Entry<'client>>,
 }
 
 impl<'client> SpiTupleTable<'client> {
     /// Wraps the current global `pg_sys::SPI_tuptable` as a new [`SpiTupleTable`] instance, with
     /// a lifetime tied to the specified [`SpiClient`].
+    ///
+    /// It is intended that that function be called to consume the globally-assigned results of
+    /// SPI functions like [`pg_sys::SPI_execute`] and [`pg_sys::SPI_cursor_fetch`].
+    ///
+    /// # Panics
+    ///
+    /// This function will panic if the provided `last_spi_status_code` is not an "OK" code.
     pub(super) fn wrap(_client: &'client SpiClient, last_spi_status_code: i32) -> SpiResult<Self> {
         Spi::check_status(last_spi_status_code)?;
 
@@ -52,9 +192,22 @@ impl<'client> SpiTupleTable<'client> {
                 (*pg_sys::SPI_tuptable).numvals as usize
             };
 
-            let tuptable = pg_sys::SPI_tuptable;
+            let table = NonNull::new(pg_sys::SPI_tuptable);
+            let natts =
+                if let Some(ref table) = table { (*table.as_ref().tupdesc).natts } else { 0 };
+            let current = Rc::new(RefCell::new(None));
 
-            Ok(Self { _client: PhantomData, table: NonNull::new(tuptable), size, current: -1 })
+            let inner = Inner { _client: PhantomData, table, size, current };
+            let entries =
+                (1..=natts as usize).map(|i| Entry { ordinal: i, inner: inner.clone() }).collect();
+            let table = Self { inner, entries };
+
+            // We should not leave pg_sys::SPI_tuptable pointing to something that we now control,
+            // as we have no visibility into what (if anything) other Postgres internals or FFI calls
+            // decide to do with it
+            pg_sys::SPI_tuptable = std::ptr::null_mut();
+
+            Ok(table)
         }
     }
 
@@ -62,22 +215,46 @@ impl<'client> SpiTupleTable<'client> {
     ///
     /// This method moves the position to the first row.  If there are no rows, this
     /// method will silently return.
-    pub fn first(mut self) -> Self {
-        self.current = 0;
+    pub fn first(self) -> Self {
+        *self.inner.current.borrow_mut() = Some(0);
         self
     }
 
     /// Restore the state of iteration back to before the start.
     ///
     /// This is useful to iterate the table multiple times
-    pub fn rewind(mut self) -> Self {
-        self.current = -1;
+    pub fn rewind(self) -> Self {
+        *self.inner.current.borrow_mut() = None;
         self
+    }
+
+    /// Position the iteration state to the next row, returning `Some(&mut Self)`.  If at the end
+    /// this function returns `None`.
+    pub fn next(&mut self) -> Option<&mut Self> {
+        let current = self.inner.current.borrow().map_or(0, |c| c + 1);
+        *self.inner.current.borrow_mut() = Some(current);
+        if current >= self.inner.size {
+            None
+        } else {
+            Some(self)
+        }
+    }
+
+    /// Takes a closure and creates an iterator which calls that closure on each row of this
+    /// [`SpiTupleTuple`], starting at the current position.
+    ///
+    /// This is akin to the standard [`std::iter::Iterator::map()`] function.
+    pub fn map<B, F>(self, f: F) -> Map<'client, F>
+    where
+        Self: Sized,
+        F: FnMut(&mut SpiTupleTable<'_>) -> B,
+    {
+        Map { table: self, f }
     }
 
     /// How many rows were processed?
     pub fn len(&self) -> usize {
-        self.size
+        self.inner.size
     }
 
     pub fn is_empty(&self) -> bool {
@@ -109,40 +286,6 @@ impl<'client> SpiTupleTable<'client> {
         Ok((a, b, c))
     }
 
-    #[inline(always)]
-    fn get_spi_tuptable(
-        &self,
-    ) -> SpiResult<(*mut pg_sys::SPITupleTable, *mut pg_sys::TupleDescData)> {
-        let table = self.table.map(|table| table.as_ptr()).ok_or(SpiError::NoTupleTable)?;
-        let tupdesc = unsafe {
-            // SAFETY:  we just assured that `table` is not null
-            table.as_mut().unwrap().tupdesc
-        };
-        Ok((table, tupdesc))
-    }
-
-    pub fn get_heap_tuple(&self) -> SpiResult<Option<SpiHeapTupleData<'client>>> {
-        if self.size == 0 || self.table.is_none() {
-            // a query like "SELECT 1 LIMIT 0" is a valid "select"-style query that will not produce
-            // a SPI_tuptable.  So are utility queries such as "CREATE INDEX" or "VACUUM".  We might
-            // think that in the latter cases we'd want to produce an error here, but there's no
-            // way to distinguish from the former.  As such, we take a gentle approach and
-            // processed with "no, we don't have one, but it's okay"
-            Ok(None)
-        } else if self.current < 0 || self.current as usize >= self.size {
-            Err(SpiError::InvalidPosition)
-        } else {
-            let (table, tupdesc) = self.get_spi_tuptable()?;
-            unsafe {
-                let heap_tuple =
-                    std::slice::from_raw_parts((*table).vals, self.size)[self.current as usize];
-
-                // SAFETY:  we know heap_tuple is valid because we just made it
-                SpiHeapTupleData::new(tupdesc, heap_tuple)
-            }
-        }
-    }
-
     /// Get a typed value by its ordinal position.
     ///
     /// The ordinal position is 1-based.
@@ -157,25 +300,7 @@ impl<'client> SpiTupleTable<'client> {
     /// This function will panic there is no parent MemoryContext.  This is an incredibly unlikely
     /// situation.
     pub fn get<T: IntoDatum + FromDatum>(&self, ordinal: usize) -> SpiResult<Option<T>> {
-        let (_, tupdesc) = self.get_spi_tuptable()?;
-        let datum = self.get_datum_by_ordinal(ordinal)?;
-        let is_null = datum.is_none();
-        let datum = datum.unwrap_or_else(|| pg_sys::Datum::from(0));
-
-        unsafe {
-            // SAFETY:  we know the constraints around `datum` and `is_null` match because we
-            // just got them from the underlying heap tuple
-            Ok(T::try_from_datum_in_memory_context(
-                PgMemoryContexts::CurrentMemoryContext
-                    .parent()
-                    .expect("parent memory context is absent"),
-                datum,
-                is_null,
-                // SAFETY:  we know `self.tupdesc.is_some()` because an Ok return from
-                // `self.get_datum_by_ordinal()` above already decided that for us
-                pg_sys::SPI_gettypeid(tupdesc, ordinal as _),
-            )?)
-        }
+        self.inner.get(ordinal)
     }
 
     /// Get a typed value by its name.
@@ -191,74 +316,16 @@ impl<'client> SpiTupleTable<'client> {
         self.get(self.column_ordinal(name)?)
     }
 
-    /// Get a raw Datum from this HeapTuple by its ordinal position.
-    ///
-    /// The ordinal position is 1-based.
-    ///
-    /// # Errors
-    ///
-    /// If the specified ordinal is out of bounds a [`Error::SpiError(SpiError::NoAttribute)`] is returned
-    /// If we have no backing tuple table a [`Error::NoTupleTable`] is returned
-    pub fn get_datum_by_ordinal(&self, ordinal: usize) -> SpiResult<Option<pg_sys::Datum>> {
-        self.check_ordinal_bounds(ordinal)?;
-
-        let (table, tupdesc) = self.get_spi_tuptable()?;
-        if self.current < 0 || self.current as usize >= self.size {
-            return Err(SpiError::InvalidPosition);
-        }
-        unsafe {
-            let heap_tuple =
-                std::slice::from_raw_parts((*table).vals, self.size)[self.current as usize];
-            let mut is_null = false;
-            let datum = pg_sys::SPI_getbinval(heap_tuple, tupdesc, ordinal as _, &mut is_null);
-
-            if is_null {
-                Ok(None)
-            } else {
-                Ok(Some(datum))
-            }
-        }
-    }
-
-    /// Get a raw Datum from this HeapTuple by its column name.
-    ///
-    /// # Errors
-    ///
-    /// If the specified name is invalid a [`Error::SpiError(SpiError::NoAttribute)`] is returned
-    /// If we have no backing tuple table a [`Error::NoTupleTable`] is returned
-    pub fn get_datum_by_name<S: AsRef<str>>(&self, name: S) -> SpiResult<Option<pg_sys::Datum>> {
-        self.get_datum_by_ordinal(self.column_ordinal(name)?)
-    }
-
     /// Returns the number of columns
     pub fn columns(&self) -> SpiResult<usize> {
-        let (_, tupdesc) = self.get_spi_tuptable()?;
-        // SAFETY:  we just got a valid tupdesc
-        Ok(unsafe { (*tupdesc).natts as _ })
-    }
-
-    /// is the specified ordinal valid for the underlying tuple descriptor?
-    #[inline]
-    fn check_ordinal_bounds(&self, ordinal: usize) -> SpiResult<()> {
-        if ordinal < 1 || ordinal > self.columns()? {
-            Err(SpiError::SpiError(SpiErrorCodes::NoAttribute))
-        } else {
-            Ok(())
-        }
+        self.inner.columns()
     }
 
     /// Returns column type OID
     ///
     /// The ordinal position is 1-based
     pub fn column_type_oid(&self, ordinal: usize) -> SpiResult<PgOid> {
-        self.check_ordinal_bounds(ordinal)?;
-
-        let (_, tupdesc) = self.get_spi_tuptable()?;
-        unsafe {
-            // SAFETY:  we just got a valid tupdesc
-            let oid = pg_sys::SPI_gettypeid(tupdesc, ordinal as i32);
-            Ok(PgOid::from(oid))
-        }
+        self.inner.column_type_oid(ordinal)
     }
 
     /// Returns column name of the 1-based `ordinal` position
@@ -273,21 +340,7 @@ impl<'client> SpiTupleTable<'client> {
     /// This function will panic if the column name at the specified ordinal position is not also
     /// a valid UTF8 string.
     pub fn column_name(&self, ordinal: usize) -> SpiResult<String> {
-        self.check_ordinal_bounds(ordinal)?;
-        let (_, tupdesc) = self.get_spi_tuptable()?;
-        unsafe {
-            // SAFETY:  we just got a valid tupdesc and we know ordinal is in bounds
-            let name = pg_sys::SPI_fname(tupdesc, ordinal as i32);
-
-            // SAFETY:  SPI_fname will have given us a properly allocated char* since we know
-            // the specified ordinal is in bounds
-            let str =
-                CStr::from_ptr(name).to_str().expect("column name is not value UTF8").to_string();
-
-            // SAFETY: we just asked Postgres to allocate name for us
-            pg_sys::pfree(name as *mut _);
-            Ok(str)
-        }
+        self.inner.column_name(ordinal)
     }
 
     /// Returns the ordinal (1-based position) of the specified column name
@@ -301,40 +354,7 @@ impl<'client> SpiTupleTable<'client> {
     ///
     /// This function will panic if somehow the specified name contains a null byte.
     pub fn column_ordinal<S: AsRef<str>>(&self, name: S) -> SpiResult<usize> {
-        let (_, tupdesc) = self.get_spi_tuptable()?;
-        unsafe {
-            let name_cstr = CString::new(name.as_ref()).expect("name contained a null byte");
-            let fnumber = pg_sys::SPI_fnumber(tupdesc, name_cstr.as_ptr());
-
-            if fnumber == pg_sys::SPI_ERROR_NOATTRIBUTE {
-                Err(SpiError::SpiError(SpiErrorCodes::NoAttribute))
-            } else {
-                Ok(fnumber as usize)
-            }
-        }
-    }
-}
-
-impl<'client> Iterator for SpiTupleTable<'client> {
-    type Item = SpiHeapTupleData<'client>;
-
-    /// # Panics
-    ///
-    /// This method will panic if for some reason the underlying heap tuple cannot be retrieved
-    #[inline]
-    fn next(&mut self) -> Option<Self::Item> {
-        self.current += 1;
-        if self.current >= self.size as isize {
-            None
-        } else {
-            assert!(self.current >= 0);
-            self.get_heap_tuple().report()
-        }
-    }
-
-    #[inline]
-    fn size_hint(&self) -> (usize, Option<usize>) {
-        (0, Some(self.size))
+        self.inner.column_ordinal(name)
     }
 }
 
@@ -343,222 +363,80 @@ impl Drop for SpiTupleTable<'_> {
         unsafe {
             // SAFETY:  self.table was created by Postgres from whatever `pg_sys::SPI_tuptable` pointed
             // to at the time this SpiTupleTable was constructed
-            if let Some(ptr) = self.table.take() {
+            if let Some(ptr) = self.inner.table.take() {
                 pg_sys::SPI_freetuptable(ptr.as_ptr())
             }
         }
     }
 }
 
-/// Represents a single `pg_sys::Datum` inside a `SpiHeapTupleData`
-pub struct SpiHeapTupleDataEntry<'client> {
-    datum: Option<pg_sys::Datum>,
-    type_oid: pg_sys::Oid,
-    __marker: PhantomData<&'client ()>,
-}
+impl<'table> Index<&str> for SpiTupleTable<'table> {
+    type Output = Entry<'table>;
 
-/// Represents the set of `pg_sys::Datum`s in a `pg_sys::HeapTuple`
-pub struct SpiHeapTupleData<'client> {
-    tupdesc: NonNull<pg_sys::TupleDescData>,
-    // offset by 1!
-    entries: Vec<SpiHeapTupleDataEntry<'client>>,
-}
-
-impl<'client> SpiHeapTupleData<'client> {
-    /// Create a new `SpiHeapTupleData` from its constituent parts
-    ///
-    /// # Safety
-    ///
-    /// This is unsafe as it cannot ensure that the provided `tupdesc` and `htup` arguments
-    /// are valid, palloc'd pointers.
-    pub unsafe fn new(
-        tupdesc: pg_sys::TupleDesc,
-        htup: *mut pg_sys::HeapTupleData,
-    ) -> SpiResult<Option<Self>> {
-        let tupdesc = NonNull::new(tupdesc).ok_or(SpiError::NoTupleTable)?;
-        let mut data = SpiHeapTupleData { tupdesc, entries: Vec::new() };
-        let tupdesc = tupdesc.as_ptr();
-
-        unsafe {
-            // SAFETY:  we know tupdesc is not null
-            let natts = (*tupdesc).natts;
-            data.entries.reserve(usize::try_from(natts as usize).unwrap_or_default());
-            for i in 1..=natts {
-                let mut is_null = false;
-                let datum = pg_sys::SPI_getbinval(htup, tupdesc as _, i, &mut is_null);
-                data.entries.push(SpiHeapTupleDataEntry {
-                    datum: if is_null { None } else { Some(datum) },
-                    type_oid: pg_sys::SPI_gettypeid(tupdesc as _, i),
-                    __marker: PhantomData,
-                });
-            }
-        }
-
-        Ok(Some(data))
-    }
-
-    /// Get a typed value from this HeapTuple by its ordinal position.
-    ///
-    /// The ordinal position is 1-based
-    ///
-    /// # Errors
-    ///
-    /// Returns a [`Error::DatumError`] if the desired Rust type is incompatible
-    /// with the underlying Datum
-    pub fn get<T: IntoDatum + FromDatum>(&self, ordinal: usize) -> SpiResult<Option<T>> {
-        self.get_datum_by_ordinal(ordinal).map(|entry| entry.value())?
-    }
-
-    /// Get a typed value from this HeapTuple by its name in the resultset.
-    ///
-    /// # Errors
-    ///
-    /// Returns a [`Error::DatumError`] if the desired Rust type is incompatible
-    /// with the underlying Datum
-    pub fn get_by_name<T: IntoDatum + FromDatum, S: AsRef<str>>(
-        &self,
-        name: S,
-    ) -> SpiResult<Option<T>> {
-        self.get_datum_by_name(name.as_ref()).map(|entry| entry.value())?
-    }
-
-    /// Get a raw Datum from this HeapTuple by its ordinal position.
-    ///
-    /// The ordinal position is 1-based.
-    ///
-    /// # Errors
-    ///
-    /// If the specified ordinal is out of bounds a [`Error::SpiError(SpiError::NoAttribute)`] is returned
-    pub fn get_datum_by_ordinal(
-        &self,
-        ordinal: usize,
-    ) -> SpiResult<&SpiHeapTupleDataEntry<'client>> {
-        // Wrapping because `self.entries.get(...)` will bounds check.
-        let index = ordinal.wrapping_sub(1);
-        self.entries.get(index).ok_or_else(|| SpiError::SpiError(SpiErrorCodes::NoAttribute))
-    }
-
-    /// Get a raw Datum from this HeapTuple by its field name.
-    ///
-    /// # Errors
-    ///
-    /// If the specified name isn't valid a [`Error::SpiError(SpiError::NoAttribute)`] is returned
+    /// Get the named attribute entry at the current position of this [`SpiTupleTable`].
     ///
     /// # Panics
     ///
-    /// This function will panic if somehow the specified name contains a null byte.
-    pub fn get_datum_by_name<S: AsRef<str>>(
-        &self,
-        name: S,
-    ) -> SpiResult<&SpiHeapTupleDataEntry<'client>> {
-        unsafe {
-            let name_cstr = CString::new(name.as_ref()).expect("name contained a null byte");
-            let fnumber = pg_sys::SPI_fnumber(self.tupdesc.as_ptr(), name_cstr.as_ptr());
-
-            if fnumber == pg_sys::SPI_ERROR_NOATTRIBUTE {
-                Err(SpiError::SpiError(SpiErrorCodes::NoAttribute))
-            } else {
-                self.get_datum_by_ordinal(fnumber as usize)
-            }
-        }
-    }
-
-    /// Set a datum value for the specified ordinal position
-    ///
-    /// # Errors
-    ///
-    /// If the specified ordinal is out of bounds a [`SpiErrorCodes::NoAttribute`] is returned
-    pub fn set_by_ordinal<T: IntoDatum>(&mut self, ordinal: usize, datum: T) -> SpiResult<()> {
-        self.check_ordinal_bounds(ordinal)?;
-        self.entries[ordinal - 1] = SpiHeapTupleDataEntry {
-            datum: datum.into_datum(),
-            type_oid: T::type_oid(),
-            __marker: PhantomData,
-        };
-        Ok(())
-    }
-
-    /// Set a datum value for the specified field name
-    ///
-    /// # Errors
-    ///
-    /// If the specified name isn't valid a [`Error::SpiError(SpiError::NoAttribute)`] is returned
-    ///
-    /// # Panics
-    ///
-    /// This function will panic if somehow the specified name contains a null byte.
-    pub fn set_by_name<T: IntoDatum>(&mut self, name: &str, datum: T) -> SpiResult<()> {
-        unsafe {
-            let name_cstr = CString::new(name).expect("name contained a null byte");
-            let fnumber = pg_sys::SPI_fnumber(self.tupdesc.as_ptr(), name_cstr.as_ptr());
-            if fnumber == pg_sys::SPI_ERROR_NOATTRIBUTE {
-                Err(SpiError::SpiError(SpiErrorCodes::NoAttribute))
-            } else {
-                self.set_by_ordinal(fnumber as usize, datum)
-            }
-        }
-    }
-
-    #[inline]
-    pub fn columns(&self) -> usize {
-        unsafe {
-            // SAFETY: we know self.tupdesc is a valid, non-null pointer because we own it
-            (*self.tupdesc.as_ptr()).natts as usize
-        }
-    }
-
-    /// is the specified ordinal valid for the underlying tuple descriptor?
-    #[inline]
-    fn check_ordinal_bounds(&self, ordinal: usize) -> SpiResult<()> {
-        if ordinal < 1 || ordinal > self.columns() {
-            Err(SpiError::SpiError(SpiErrorCodes::NoAttribute))
-        } else {
-            Ok(())
-        }
+    /// This method will panic if the specified attribute name is not found
+    fn index(&self, name: &str) -> &Self::Output {
+        let ordinal = self
+            .column_ordinal(name)
+            .unwrap_or_else(|_| panic!("no such attribute named `{}`", name));
+        let index = ordinal - 1; // ordinals are 1-based, but we're not
+        self.entries.get(index).unwrap()
     }
 }
 
-impl<'client> SpiHeapTupleDataEntry<'client> {
+impl<'table> Index<usize> for SpiTupleTable<'table> {
+    type Output = Entry<'table>;
+
+    /// Get the numbered attribute entry at the current position of this [`SpiTupleTable`].
+    ///
+    /// The `index` argument ordinal position is 1-based.
+    ///
+    /// # Panics
+    ///
+    /// This method will panic if the specific ordinal position is out of bounds
+    fn index(&self, ordinal: usize) -> &Self::Output {
+        self.inner.check_ordinal_bounds(ordinal).expect("ordinal out of bounds");
+        let index = ordinal - 1; // ordinals are 1-based, but we're not
+        self.entries.get(index).unwrap()
+    }
+}
+
+pub struct Map<'client, F> {
+    table: SpiTupleTable<'client>,
+    f: F,
+}
+
+impl<'client, B, F> Iterator for Map<'_, F>
+where
+    F: FnMut(&mut SpiTupleTable) -> B,
+{
+    type Item = B;
+
+    #[inline]
+    fn next(&mut self) -> Option<B> {
+        self.table.next().map(&mut self.f)
+    }
+
+    #[inline]
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        (0, Some(self.table.inner.size))
+    }
+}
+
+/// A lightweight wrapper representing an attribute entry within a [`SpiHeapTuple`]
+#[derive(Debug)]
+pub struct Entry<'table> {
+    ordinal: usize,
+    inner: Inner<'table>,
+}
+
+impl<'table> Entry<'table> {
+    /// Retrieve the value of this [`Entry`] from the current row of its associated table.
+    #[inline]
     pub fn value<T: IntoDatum + FromDatum>(&self) -> SpiResult<Option<T>> {
-        match self.datum.as_ref() {
-            Some(datum) => unsafe {
-                T::try_from_datum_in_memory_context(
-                    PgMemoryContexts::CurrentMemoryContext
-                        .parent()
-                        .expect("parent memory context is absent"),
-                    *datum,
-                    false,
-                    self.type_oid,
-                )
-                .map_err(|e| SpiError::DatumError(e))
-            },
-            None => Ok(None),
-        }
-    }
-
-    pub fn oid(&self) -> pg_sys::Oid {
-        self.type_oid
-    }
-}
-
-/// Provide ordinal indexing into a `SpiHeapTupleData`.
-///
-/// If the index is out of bounds, it will panic
-impl<'client> Index<usize> for SpiHeapTupleData<'client> {
-    type Output = SpiHeapTupleDataEntry<'client>;
-
-    fn index(&self, index: usize) -> &Self::Output {
-        self.get_datum_by_ordinal(index).expect("invalid ordinal value")
-    }
-}
-
-/// Provide named indexing into a `SpiHeapTupleData`.
-///
-/// If the field name doesn't exist, it will panic
-impl<'client> Index<&str> for SpiHeapTupleData<'client> {
-    type Output = SpiHeapTupleDataEntry<'client>;
-
-    fn index(&self, index: &str) -> &Self::Output {
-        self.get_datum_by_name(index).expect("invalid field name")
+        self.inner.get(self.ordinal)
     }
 }


### PR DESCRIPTION
This removes `SpiHeapTupleData` and `SpiHeapTupleDataEntry` in favor of something that is hopefully less complex.

We also change `SpiTupleTable` to *kinda* look like an Iterator rather than actually implement `std::iter::Iterator`.  This is a breaking API change, but a good one.  The changes are reflected in the test and example code diffs.

`SpiTupleTable` has also been split up into a private `Inner` struct that manages access to the wrapped `pg_sys::SPI_tuptable` instance, allowing `SpiTupleTable` to manage its lifetime.  This also allows us to clone the inner object and share the "current row number" `Inner::current` across all the `Entry`-ies.

Doing so avoids the need for the old `SpiHeapTupleData` type entirely while allowing us to `impl Index for SpiTupleTable`, which accesses attributes (columns) by their name or ordinal at the current position of the SpiTupleTable.

ping @workingjubilee for review